### PR TITLE
READY: make vello optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,11 +110,13 @@ workspace = true
 
 [dependencies]
 vello = { workspace = true, optional = true }
-kurbo = { workspace = true }
-peniko = { workspace = true }
 keyframe = "1.1.1"
 once_cell = "1.21.3"
 thiserror = "2.0.12"
+
+[target.'cfg(not(feature = "vello"))'.dependencies]
+kurbo = { workspace = true }
+peniko = { workspace = true }
 
 # For the parser
 serde = { version = "1.0.219", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,12 +102,16 @@ clippy.wildcard_dependencies = "warn"
 [workspace.dependencies]
 # NOTE: Make sure to keep this in sync with the version badge in README.md
 vello = { version = "0.5.0", default-features = false }
+kurbo = { version = "0.11.2" }
+peniko = { version = "0.4.0" }
 
 [lints]
 workspace = true
 
 [dependencies]
-vello = { workspace = true }
+vello = { workspace = true, optional = true }
+kurbo = { workspace = true }
+peniko = { workspace = true }
 keyframe = "1.1.1"
 once_cell = "1.21.3"
 thiserror = "2.0.12"
@@ -123,3 +127,4 @@ wasm-bindgen-test = "0.3.50"
 [features]
 default = []
 wgpu = ["vello/wgpu"]
+vello = ["dep:vello"]

--- a/examples/scenes/Cargo.toml
+++ b/examples/scenes/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 vello = { workspace = true }
-velato = { path = "../.." }
+velato = { path = "../..", features = ["vello"] }
 anyhow = "1"
 clap = { version = "4.5.38", features = ["derive"] }
 image = "0.24.9"

--- a/src/import/builders.rs
+++ b/src/import/builders.rs
@@ -6,7 +6,7 @@ use super::defaults::FLOAT_VALUE_ONE_HUNDRED;
 use crate::runtime::model::Layer;
 use crate::schema::helpers::int_boolean::BoolInt;
 use crate::{runtime, schema};
-use vello::peniko::{self, BlendMode, Compose, Mix};
+use peniko::{self, BlendMode, Compose, Mix};
 
 pub fn setup_precomp_layer(
     source: &schema::layers::precomposition::PrecompositionLayer,

--- a/src/import/builders.rs
+++ b/src/import/builders.rs
@@ -6,6 +6,9 @@ use super::defaults::FLOAT_VALUE_ONE_HUNDRED;
 use crate::runtime::model::Layer;
 use crate::schema::helpers::int_boolean::BoolInt;
 use crate::{runtime, schema};
+#[cfg(feature = "vello")]
+use vello::peniko::{self, BlendMode, Compose, Mix};
+#[cfg(not(feature = "vello"))]
 use peniko::{self, BlendMode, Compose, Mix};
 
 pub fn setup_precomp_layer(

--- a/src/import/converters.rs
+++ b/src/import/converters.rs
@@ -18,8 +18,10 @@ use crate::schema::constants::gradient_type::GradientType;
 use crate::schema::helpers::int_boolean::BoolInt;
 use crate::{Composition, schema};
 use std::collections::HashMap;
-use vello::kurbo::{Cap, Join, Point, Size, Vec2};
-use vello::peniko::{BlendMode, Color, Mix};
+use {
+    kurbo::{Cap, Join, Point, Size, Vec2},
+    peniko::{BlendMode, Color, Mix}
+};
 
 pub fn conv_animation(source: schema::Animation) -> Composition {
     let mut target = Composition {

--- a/src/import/converters.rs
+++ b/src/import/converters.rs
@@ -18,6 +18,12 @@ use crate::schema::constants::gradient_type::GradientType;
 use crate::schema::helpers::int_boolean::BoolInt;
 use crate::{Composition, schema};
 use std::collections::HashMap;
+#[cfg(feature = "vello")]
+use vello::{
+    kurbo::{Cap, Join, Point, Size, Vec2},
+    peniko::{BlendMode, Color, Mix}
+};
+#[cfg(not(feature = "vello"))]
 use {
     kurbo::{Cap, Join, Point, Size, Vec2},
     peniko::{BlendMode, Color, Mix}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,9 @@ mod error;
 pub use error::Error;
 
 // Re-export vello
-pub use vello;
+#[cfg(feature = "vello")]
+pub use {vello, runtime::Renderer};
 
-pub use runtime::{Composition, Renderer, model};
+pub use {kurbo, peniko};
+
+pub use runtime::{Composition, model};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub use error::Error;
 // Re-export vello
 #[cfg(feature = "vello")]
 pub use {vello, runtime::Renderer};
-
+#[cfg(not(feature = "vello"))]
 pub use {kurbo, peniko};
 
 pub use runtime::{Composition, model};

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2024 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[cfg(feature = "vello")]
 mod render;
 
 use crate::Error;
@@ -11,6 +12,7 @@ use std::ops::Range;
 
 pub mod model;
 
+#[cfg(feature = "vello")]
 pub use render::Renderer;
 
 /// Model of a Lottie file.

--- a/src/runtime/model/fixed.rs
+++ b/src/runtime/model/fixed.rs
@@ -5,8 +5,10 @@
 Representations of fixed (non-animated) values.
 */
 
-use vello::kurbo::{self, Affine, Point, Vec2};
-use vello::peniko;
+use { 
+    kurbo::{self, Affine, Point, Vec2},
+    peniko
+};
 
 /// Fixed affine transformation.
 pub type Transform = kurbo::Affine;

--- a/src/runtime/model/fixed.rs
+++ b/src/runtime/model/fixed.rs
@@ -5,6 +5,12 @@
 Representations of fixed (non-animated) values.
 */
 
+#[cfg(feature = "vello")]
+use vello::{ 
+    kurbo::{self, Affine, Point, Vec2},
+    peniko
+};
+#[cfg(not(feature = "vello"))]
 use { 
     kurbo::{self, Affine, Point, Vec2},
     peniko

--- a/src/runtime/model/mod.rs
+++ b/src/runtime/model/mod.rs
@@ -2,6 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ops::Range;
+#[cfg(feature = "vello")]
+use vello::{
+    kurbo::{self, Affine, PathEl, Point, Shape as _, Size, Vec2},
+    peniko::{self, BlendMode, Color}
+};
+#[cfg(not(feature = "vello"))]
 use {
     kurbo::{self, Affine, PathEl, Point, Shape as _, Size, Vec2},
     peniko::{self, BlendMode, Color}

--- a/src/runtime/model/mod.rs
+++ b/src/runtime/model/mod.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::ops::Range;
-use vello::kurbo::{self, Affine, PathEl, Point, Shape as _, Size, Vec2};
-use vello::peniko::{self, BlendMode, Color};
+use {
+    kurbo::{self, Affine, PathEl, Point, Shape as _, Size, Vec2},
+    peniko::{self, BlendMode, Color}
+};
 
 mod spline;
 mod value;

--- a/src/runtime/model/spline.rs
+++ b/src/runtime/model/spline.rs
@@ -1,7 +1,7 @@
 // Copyright 2024 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use vello::kurbo::{PathEl, Point};
+use kurbo::{PathEl, Point};
 
 /// Helper trait for converting cubic splines to paths.
 pub trait SplineToPath {

--- a/src/runtime/model/spline.rs
+++ b/src/runtime/model/spline.rs
@@ -1,6 +1,9 @@
 // Copyright 2024 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[cfg(feature = "vello")]
+use vello::kurbo::{PathEl, Point};
+#[cfg(not(feature = "vello"))]
 use kurbo::{PathEl, Point};
 
 /// Helper trait for converting cubic splines to paths.

--- a/src/runtime/model/value.rs
+++ b/src/runtime/model/value.rs
@@ -1,6 +1,9 @@
 // Copyright 2024 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+#[cfg(feature = "vello")]
+use vello::{kurbo::{self}, peniko};
+#[cfg(not(feature = "vello"))]
 use {kurbo::{self}, peniko};
 
 /// Fixed or animated value.

--- a/src/runtime/model/value.rs
+++ b/src/runtime/model/value.rs
@@ -1,8 +1,7 @@
 // Copyright 2024 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use vello::kurbo::{self};
-use vello::peniko;
+use {kurbo::{self}, peniko};
 
 /// Fixed or animated value.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
Goal: Move Vello behind a feature flag and make it default feature so that Velato can be independent of Vello to run under Wasm and browsers. This removes the heavy wgpu dependency.

What changed:

- All Vello imports and related code ( like render.rs ) is now gated behind the `vello` feature.
- `vello` feature enabled by default, so old behavior will not change.
- Direct imports of kurbo and peniko are used if `vello` feature isn't enabled.

Pros:

- Velato can now be used as a library independently of any renderer, making it a good Lottie parser.
- Velato can be independent of heavy wgpu dependency.

Cons:

- The versions of kurbo and peniko must be kept in sync between Vello and Velato.